### PR TITLE
Update POT_tutorial_BASICS.ipynb

### DIFF
--- a/POT_tutorial_BASICS.ipynb
+++ b/POT_tutorial_BASICS.ipynb
@@ -2071,7 +2071,7 @@
     }
    ],
    "source": [
-    "!python3 /opt/intel/openvino/deployment_tools/tools/benchmark_tool/benchmark_app.py -m results/optimized/SampLeNet_DefaultQuantization.xml"
+    "!python3 /opt/intel/openvino/deployment_tools/tools/benchmark_tool/benchmark_app.py -m results/optimized/SampLeNet_AccuracyAware.xml"
    ]
   },
   {


### PR DESCRIPTION
Hi,

While running the tutorial I found that the last step includes SampLeNet_DefaultQuantization.xml but it should be SampLeNet_AccuracyAware.xml. Not sure if the console output after that is right or not, perhaps it should also be updated. 

I have also found some typos which I will correct and suggest as a separate PR. 